### PR TITLE
Fix register handling in i2cset

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # Low-signal
+
+This repository contains an Arduino sketch for experimenting with EEPROM and basic I2C commands.

--- a/sketch_apr21e.ino
+++ b/sketch_apr21e.ino
@@ -78,9 +78,10 @@ void i2cScan(int bus) {
   }
 }
 
-void i2cSet(int bus, int address, byte value) {
+void i2cSet(int bus, int address, int reg, byte value) {
   Wire.beginTransmission(address);
-  Wire.write(value);
+  Wire.write(reg);        // select register
+  Wire.write(value);      // write value
   Wire.endTransmission();
   Serial.println("Value set successfully.");
 }
@@ -148,12 +149,16 @@ void loop() {
       if (spaceIndex != -1) {
         int addrIndex = command.indexOf("0x", spaceIndex + 1);
         if (addrIndex != -1) {
-          int valueIndex = command.indexOf("0x", addrIndex + 1);
-          if (valueIndex != -1) {
-            int bus = command.substring(spaceIndex + 1, addrIndex).toInt();
-            int address = strtol(command.substring(addrIndex, valueIndex).c_str(), NULL, 16);
-            byte value = strtol(command.substring(valueIndex).c_str(), NULL, 16);
-            i2cSet(bus, address, value);
+          int regIndex = command.indexOf("0x", addrIndex + 1);
+          if (regIndex != -1) {
+            int valueIndex = command.indexOf("0x", regIndex + 1);
+            if (valueIndex != -1) {
+              int bus = command.substring(spaceIndex + 1, addrIndex).toInt();
+              int address = strtol(command.substring(addrIndex, regIndex).c_str(), NULL, 16);
+              int reg = strtol(command.substring(regIndex, valueIndex).c_str(), NULL, 16);
+              byte value = strtol(command.substring(valueIndex).c_str(), NULL, 16);
+              i2cSet(bus, address, reg, value);
+            }
           }
         }
       }


### PR DESCRIPTION
## Summary
- make README readable
- allow `i2cset` to specify a register

## Testing
- `arduino-cli compile --fqbn arduino:avr:uno` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685028b096648325903a5500c30159d2